### PR TITLE
Expand options to set new target

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,16 +31,22 @@ const App = () => {
 
   useEffect(updateResults, [projectSlug]);
   
-  const addDefaultTarget = (targetName, targetSlug, targetRegion) => {
+  const addDefaultTarget = (targetName, targetSlug, externalHostname, externalDomain, ipWhitelist, proxyConfigs, targetRegion) => {
     const URL = `/api/projects/${projectSlug}/target/`;
-    const hostname = `${projectSlug}-${targetSlug}.mobify-storefront.com`;
-    const body = {
+
+    let body = {
       name: targetName,
-      slug: targetSlug,
-      ssr_external_hostname: hostname,
-      ssr_external_domain: 'mobify-storefront.com',
-      ssr_region: targetRegion
+      ssr_whitelisted_ips: ipWhitelist,
+      ssr_proxy_configs: proxyConfigs,
+      ssr_region: targetRegion,
     };
+
+    Object.assign(body,
+      targetSlug.length > 0 ? {slug: targetSlug} : null,
+      externalHostname.length > 0 ? {ssr_external_hostname: externalHostname} : null,
+      externalDomain.length > 0 ? {ssr_external_domain: externalDomain} : null
+    )
+
     console.log(`I got called with name of ${targetName} and slug of ${targetSlug}!`);
     fetch(URL, {
       method: 'post',

--- a/src/CreateTarget.js
+++ b/src/CreateTarget.js
@@ -9,15 +9,23 @@ import './CreateTarget.css';
 const CreateTarget = (props) => {
     const [targetName, setTargetName] = useState('');
     const [targetSlug, setTargetSlug] = useState('');
+    const [externalHostname, setHostNameSlug] = useState('');
+    const [externalDomain, setDomainSlug] = useState('');
+    const [ipWhitelist, setIpWhitelistSlug] = useState('');
+    const [proxyConfigs, setProxyConfigsSlug] = useState('');
     const [targetRegion, setTargetRegion] = useState('us-east-2');
 
     const click = props.cb;
 
     const buttonClick = () => {
-        if (targetName.length > 0 && targetSlug.length > 0) {
-            click(targetName, targetSlug, targetRegion);
+        if (targetName.length > 0) {
+            click(targetName, targetSlug, externalHostname, externalDomain, ipWhitelist, proxyConfigs, targetRegion);
             setTargetName('');
             setTargetSlug('');
+            setHostNameSlug('');
+            setDomainSlug('');
+            setIpWhitelistSlug('');
+            setProxyConfigsSlug('');
             setTargetRegion('us-east-2')
         }
     }
@@ -29,6 +37,14 @@ const CreateTarget = (props) => {
                 onChange={(e) => setTargetName(e.target.value)} />
             <Input type="text" name="targetSlug" value={targetSlug} placeholder="Target Slug" 
                 onChange={(e) => setTargetSlug(e.target.value)} />
+            <Input type="text" name="external_hostname" value={externalHostname} placeholder="External Hostname" 
+                onChange={(e) => setHostNameSlug(e.target.value)} />
+            <Input type="text" name="external_domain" value={externalDomain} placeholder="External Domain" 
+                onChange={(e) => setDomainSlug(e.target.value)} />
+            <Input type="text" name="ip_whitelist" value={ipWhitelist} placeholder="IP Whitelist" 
+                onChange={(e) => setIpWhitelistSlug(e.target.value)} />
+            <Input type="text" name="proxy_configs" value={proxyConfigs} placeholder="Proxy Configs" 
+                onChange={(e) => setProxyConfigsSlug(e.target.value)} />
             <Select name="targetRegion" id="targetRegion" value={targetRegion}
                 onChange={(e) => setTargetRegion(e.target.value)}>
                 <MenuItem value="us-east-1" selected>US East (N. Virginia)</MenuItem>


### PR DESCRIPTION
This allows a user to enter values for the other parameters taken in by the create target API call.

This also removes the requirement to set a slug as the only required parameters are name and region.

Changes:
Added input fields for external hostname, external domain, ip whitelist, and proxy configs.
Removed requirement on entering a slug.

Future changes:
Error handling if the external hostname or domain entered is not an allowed value (I think these two require a format of abc.xyz)
